### PR TITLE
Combine results with Jshint results

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ gulp.task('polylint', function() {
     .pipe(jshint.reporter("fail"));
 });
 ```
+The `combineWithJshintResults` function can also be called with a configuration object:
+```
+...
+    .pipe(polylint.combineWithJshintResults({ ignoreWarnings: true }))
+...
+```
+Currently the only option is `ignoreWarnings` which defaults to false. If set to true, polylint warnings (not fatal) will be skipped in the process.
 
 ## License
 MIT © Andrew Johnston

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ gulp.task('polylint', function() {
 });
 ```
 
+## Combine results with those of JSHint
+Inspired by [gulp-jscs-stylish](https://github.com/gonsfx/gulp-jscs-stylish#combine-results-with-those-of-jshint) there is also a feature to combine the polylint results with those of [JSHint](https://github.com/spalger/gulp-jshint):
+```
+var gulp     = require('gulp');
+var polylint = require('gulp-polylint');
+var jshint   = require('gulp-jshint');
+
+gulp.task('polylint', function() {
+  return gulp.src('app/elements/**/*.html')
+    .pipe(polylint())
+    .pipe(jshint.extract("auto"))
+    .pipe(jshint())
+    .pipe(polylint.combineWithJshintResults())
+    .pipe(jshint.reporter("jshint-stylish"))
+    .pipe(jshint.reporter("fail"));
+});
+```
 
 ## License
 MIT © Andrew Johnston

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-polylint",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Polylint plugin for gulp",
   "license": "MIT",
   "repository": "ajjohnston/gulp-polylint",
@@ -16,7 +16,8 @@
     "log-symbols": "^1.0.2",
     "plur": "^2.1.2",
     "polylint": "^2.10.0",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "gulp-tap": "^0.1.3"
   },
   "keywords": [
     "gulp",

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ function byErrorLine (a, b) {
 function tapPolylint (action) {
   return function (opts) {
     opts = opts || {};
-    var ignoreWarnings = opts.ignoreWarnings !== false;
+    var ignoreWarnings = opts.ignoreWarnings || false;
     return tap(function (file) {
       if (!file.polylint) {
         return;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 var polylint = require('polylint');
 var through2 = require('through2');
 var extend = require('extend');
+var path = require('path');
+var tap = require('gulp-tap');
 
 var reporters = require('./reporter');
 
@@ -40,3 +42,52 @@ polylintPlugin.reporter = reporters;
 polylintPlugin.reporter.stylishlike = require('./reporters/stylishlike');
 
 module.exports = polylintPlugin;
+
+function byErrorLine (a, b) {
+  return a.error.line - b.error.line;
+}
+
+function tapPolylint (action) {
+  return function (opts) {
+    opts = opts || {};
+    var ignoreWarnings = opts.ignoreWarnings !== false;
+    return tap(function (file) {
+      if (!file.polylint) {
+        return;
+      }
+      action(file, ignoreWarnings);
+    });
+  };
+}
+
+function toJshint (file, ignoreWarnings) {
+  var errorList = file.polylint.results;
+  var filePath = path.relative(process.cwd(), file.path);
+
+  var results = [];
+  errorList.forEach(function (error) {
+    if (!ignoreWarnings || error.fatal) {
+      results.push({
+        file: filePath,
+        error: {
+          character: error.location.column,
+          code: (error.fatal ? 'E' : 'W') + ' polylint',
+          line: error.location.line,
+          reason: error.message
+        }
+      });
+    }
+  });
+  
+  return results;
+}
+
+module.exports.combineWithJshintResults = tapPolylint(function (file, ignoreWarnings) {
+  var results = toJshint(file, ignoreWarnings);
+  if (results.length > 0) {
+    file.jshint = file.jshint || {};
+    file.jshint.success = false;
+    file.jshint.results = (file.jshint.results || []).concat(results);
+    file.jshint.results.sort(byErrorLine);
+  }
+});


### PR DESCRIPTION
This is a solution for #3.
Note that there is no direct dependency to JSHint or stylish, the code just fills the `file.jshint` object with the converted results from polylint. [gulp-jscs-stylish](https://github.com/gonsfx/gulp-jscs-stylish#combine-results-with-those-of-jshint) does the same, but also provides a reporter based on [jshint-stylish](https://github.com/sindresorhus/jshint-stylish) which introduces the dependency to jshint.
I decided to do it this way, because combining the result objects and reporting are 2 different things. If you don't like the idea, feel free to provide a new reporter based on gulp-jscs-stylish which includes the conversion code from this PR.
