### PR TITLE
no Recursion Option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,18 @@ The `combineWithJshintResults` function can also be called with a configuration 
     .pipe(polylint.combineWithJshintResults({ ignoreWarnings: true }))
 ...
 ```
+
 Currently the only option is `ignoreWarnings` which defaults to false. If set to true, polylint warnings (not fatal) will be skipped in the process.
+
+
+The `polylint` function can also be called with a configuration object:
+```
+...
+    .pipe(polylint({ noRecursion: true }))
+...
+```
+Currently the only option is `noRecursion` which defaults to false. If set to true, polylint will only report errors on specified input files, not from their dependencies.
+
 
 ## License
 MIT © Andrew Johnston

--- a/src/index.js
+++ b/src/index.js
@@ -27,14 +27,23 @@ var polylintPlugin = function (opts) {
 
     opts = extend(defaults, opts);
 
-    polylint(filename, opts)
-      .then(function (results) {
-        file.polylint = {
-          results: results
-        };
+      polylint(filename, opts)
+          .then(function (results) {
+              // option noRecursion like in polylint cli
+              var filtered = results.filter(function (warning) {
+                  if (opts.noRecursion && filename !== warning.filename) {
+                      return false
+                  } else {
+                      return true;
+                  }
+              });
 
-        return cb(null, file);
-      });
+              file.polylint = {
+                  results: filtered
+              };
+
+              return cb(null, file);
+          });
   });
 };
 
@@ -79,7 +88,7 @@ function toJshint (file, ignoreWarnings) {
       });
     }
   });
-  
+
   return results;
 }
 


### PR DESCRIPTION
Only report errors on specified input files, not from their dependencies.
Like the --no-recursion option in polylint cli command.
